### PR TITLE
[Chore] GitHub jira 이슈 연동

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,0 +1,49 @@
+name: '이슈 생성'
+description: 'Repo에 이슈를 생성하며, 생성된 이슈는 Jira와 연동됩니다.'
+title: '이슈 이름을 작성해주세요'
+body:
+  - type: input
+    id: parentKey
+    attributes:
+      label: '🎟️ 상위 작업 (Ticket Number)'
+      description: '상위 작업의 Ticket Number를 기입해주세요'
+      placeholder: 'BP-00'
+    validations:
+      required: true
+
+  - type: input
+    id: description
+    attributes:
+      label: '📝 상세 내용(Description)'
+      description: '이슈에 대해서 간략히 설명해주세요'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issueLabel
+    attributes:
+      label: '🏷️ label'
+      description: '이슈의 유형을 선택해주세요'
+      multiple: true
+      options:
+        - feat
+        - fix
+        - bug
+        - docs
+        - refactor
+        - chore
+        - HOTFIX
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: '✅ 체크리스트(Tasks)'
+      description: '해당 이슈에 대해 필요한 작업목록을 작성해주세요'
+      value: |
+        - [ ] Task1
+        - [ ] Task2
+        - [ ] Task3
+    validations:
+      required: true

--- a/.github/close-jira-issue
+++ b/.github/close-jira-issue
@@ -1,0 +1,32 @@
+name: Close Jira issue
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  close-issue:
+    name: Close Jira issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Extract Jira issue key from GitHub issue title
+        id: extract-key
+        run: |
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
+          echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+
+      - name: Close Jira issue
+        if: env.JIRA_KEY != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ env.JIRA_KEY }}
+          transition: 완료

--- a/.github/create-jira-issue
+++ b/.github/create-jira-issue
@@ -1,0 +1,81 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout dev code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/issue-form.yml
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: BP
+          issuetype: 하위 작업
+          summary: '${{ github.event.issue.title }}'
+          description: '${{ steps.md2jira.outputs.output-text }}'
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.issue-parser.outputs.issueparser_parentKey }}/${{ steps.create.outputs.issue }} was created"
+
+      - name: Create branch with Ticket number
+        run: |
+          LABELS="${{ steps.issue-parser.outputs.issueparser_issueLabel }}"
+          BRANCH_PREFIX="${LABELS%%,*}"
+          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
+          BRANCH_NAME="${BRANCH_PREFIX}/${ISSUE_NUMBER}"
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "update-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: 'Jira Issue Created: [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})'
+

--- a/.github/create-jira-issue
+++ b/.github/create-jira-issue
@@ -55,15 +55,6 @@ jobs:
       - name: Log created issue
         run: echo "Jira Issue ${{ steps.issue-parser.outputs.issueparser_parentKey }}/${{ steps.create.outputs.issue }} was created"
 
-      - name: Create branch with Ticket number
-        run: |
-          LABELS="${{ steps.issue-parser.outputs.issueparser_issueLabel }}"
-          BRANCH_PREFIX="${LABELS%%,*}"
-          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
-          BRANCH_NAME="${BRANCH_PREFIX}/${ISSUE_NUMBER}"
-          git checkout -b "${BRANCH_NAME}"
-          git push origin "${BRANCH_NAME}"
-
       - name: Update issue title
         uses: actions-cool/issues-helper@v3
         with:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!--  ex) #이슈번호, #이슈번호 -->

## 📝 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 💬 리뷰 요구사항 (Optional)
<!-- 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

## 🧪 테스트 케이스 (Optional)

<!-- 해당 PR에서 기능을 개발하면서 고려한 케이스들을 작성해주세요.  -->

## 📷 결과 (Optional)

<!-- 개발한 내용의 결과를 설명해주세요. !-->

<!-- 
gif, 사진을 위한 Table

| | | |
|--|--|--|
|<img src="" width="250">|<img src="" width="250">|<img src="" width="250">|
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jira 연동을 위한 새로운 GitHub 이슈 템플릿이 추가되었습니다.
  * GitHub 이슈 생성 시 자동으로 Jira 이슈를 생성하고 동기화하는 워크플로우가 도입되었습니다.
  * GitHub 이슈가 닫힐 때 연동된 Jira 이슈를 자동으로 완료 상태로 전환하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->