### PR TITLE
Refactor/#67-휴게시간 설정 스크롤 범위 변경

### DIFF
--- a/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppBrakeTimeSettingView.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppBrakeTimeSettingView.swift
@@ -57,6 +57,18 @@ public struct AppBrakeTimeSettingView: View {
                             .foregroundColor(.grey600)
                     }
                 }
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture()
+                        .updating($dragState) { value, state, _ in
+                            state = value.translation
+                            handleDragUpdate(value: value)
+                        }
+                        .onEnded { value in
+                            handleSwipe(value: value)
+                        }
+                )
                 Spacer()
 
                 // 완료 버튼
@@ -129,16 +141,6 @@ fileprivate extension AppBrakeTimeSettingView {
                     .offset(y: -2)
             }
         }
-        .gesture(
-            DragGesture()
-                .updating($dragState) { value, state, _ in
-                    state = value.translation
-                    handleDragUpdate(value: value)
-                }
-                .onEnded { value in
-                    handleSwipe(value: value)
-                }
-        )
     }
     
     private func handleDragUpdate(value: DragGesture.Value) {

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppBrakeTimeSettingView.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppBrakeTimeSettingView.swift
@@ -46,7 +46,7 @@ public struct AppBrakeTimeSettingView: View {
                     }
                     .frame(height: 60)
                     
-                    dragView
+                    timeSelectionView
 
                     VStack(alignment: .center, spacing: 10) {
                         Text(viewModel.getLowerNearNumber())
@@ -109,7 +109,7 @@ public struct AppBrakeTimeSettingView: View {
 
 fileprivate extension AppBrakeTimeSettingView {
     
-    @ViewBuilder var dragView: some View {
+    @ViewBuilder var timeSelectionView: some View {
         ZStack {
             // 배경
             RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!--  ex) #이슈번호, #이슈번호 -->
close #67  

## 📝 작업 내용

`AppBrakeTimeSettingView`의 드래그 제스처가 `timeSelectionView`만이 아닌 전체 스택뷰 영역에서 작동하도록 수정했습니다.

### 🔧 수정 내용
```swift
// Before: dragView에서만 드래그 가능
@ViewBuilder var dragView: some View {
    // ... 시간 선택 UI
}
.gesture(DragGesture()...)

// After: 전체 영역에서 드래그 가능  
VStack(alignment: .center, spacing: 8) {
    // ... 텍스트들과 timeSelectionView
}
.frame(maxWidth: .infinity)
.contentShape(Rectangle())
.gesture(DragGesture()...)
```

### ✨ 추가된 Modifier
- **`.frame(maxWidth: .infinity)`**: VStack이 화면 전체 너비를 차지하도록 설정
- **`.contentShape(Rectangle())`**: 드래그 제스처 인식 영역을 전체 사각형으로 확장

### 🔄 변경된 네이밍
- `dragView` → `timeSelectionView`: 더 명확한 의미를 가진 이름으로 변경

### �� 개선 효과
- 사용자가 중앙 영역 어디를 드래그해도 시간 변경 가능
- 더 넓은 드래그 영역으로 사용성 향상
- `timeSelectionView` 주변 텍스트 영역까지 드래그 가능

### ✅ 테스트 항목
- [x] 중앙 영역 전체에서 드래그 제스처 정상 작동
- [x] 시간 변경이 정상적으로 이루어짐

## 📷 결과 (Optional)

<!-- 개발한 내용의 결과를 설명해주세요. !-->

| 기존 | 변경 | 
|--|--|
|<img src="https://github.com/user-attachments/assets/013e1033-4eba-4a2b-9aad-0c7310f48da8" width="250">|<img src="https://github.com/user-attachments/assets/67fa0124-7ecb-473a-aee7-ac6529541771" width="250">|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 시간 선택 영역의 드래그 제스처 인식 범위가 확대되어 더 넓은 영역에서 제스처가 동작합니다.  
  * 시간 선택 뷰의 명칭이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->