### PR TITLE
Refactor/#72 screentime noti reauth

### DIFF
--- a/History/#72-reauth-swiftui-view.md
+++ b/History/#72-reauth-swiftui-view.md
@@ -217,3 +217,119 @@ public struct UserNotificationAuthView: View {
     }
 }
 ```
+
+## 🎯 앱 최상단 권한 변경 대응 시스템 구축
+
+### 핵심 문제: 권한 변경 감지 및 실시간 대응
+
+#### 기존 문제점
+- 사용자가 설정에서 권한을 취소해도 앱이 이를 감지하지 못함
+- 특정 화면에서만 권한 체크가 이루어져 일관성 부족
+- 앱 포그라운드 진입 시 권한 상태 변경에 대한 대응 부재
+
+#### 해결한 앱 최상단 권한 감지 시스템
+
+```swift
+// MainAppView.swift - 앱 최상단에서 권한 상태 관리
+struct MainAppView: View {
+    @State private var mainAppViewModel = MainAppViewModel()
+    
+    var body: some View {
+        MainTabView()
+            .environment(mainAppViewModel)
+            .modifier(MainAuthModifier(viewModel: mainAppViewModel))  // 🔥 핵심: 앱 전체에 권한 체크 적용
+            .onAppear {
+                mainAppViewModel.checkAllPermissions()  // 앱 시작 시 권한 확인
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+                mainAppViewModel.checkAllPermissions()  // 포그라운드 진입 시 권한 재확인
+            }
+    }
+}
+```
+
+### 실시간 권한 상태 추적 시스템
+
+```swift
+// MainAppViewModel.swift - 권한 상태 중앙 관리
+@Observable
+public final class MainAppViewModel {
+    public var authState: AuthState = .checking
+    
+    public func checkAllPermissions() {
+        Task { @MainActor in
+            let isNotificationAuthorized = await fetchUserNotificationAuthUseCase.execute()
+            let isScreenTimeAuthorized = await fetchScreenTimeAuthUseCase.execute()
+            
+            // 🔥 핵심: 권한 상태 변경 즉시 UI 업데이트
+            updateAuthState(notification: isNotificationAuthorized, screenTime: isScreenTimeAuthorized)
+        }
+    }
+    
+    private func updateAuthState(notification: Bool, screenTime: Bool) {
+        switch (notification, screenTime) {
+        case (false, _):
+            authState = .notificationRequired
+        case (true, false):
+            authState = .screenTimeRequired  
+        case (true, true):
+            authState = .authorized
+        }
+    }
+}
+```
+
+### fullScreenCover를 통한 전역 권한 요청 시스템
+
+```swift
+// MainAuthModifier.swift - 앱 어디서든 권한 요청 화면 표시
+struct MainAuthModifier: ViewModifier {
+    @Bindable var viewModel: MainAppViewModel
+    
+    func body(content: Content) -> some View {
+        content
+            .fullScreenCover(isPresented: .constant(shouldShowAuthScreen)) {
+                // 🔥 핵심: 권한 상태에 따라 적절한 화면 자동 표시
+                switch viewModel.authState {
+                case .notificationRequired:
+                    UserNoficationAuth(showNaivgation: false, ...)
+                case .screenTimeRequired:
+                    MainScreenTimeAuthView(showNaivgation: false, ...)
+                default:
+                    EmptyView()
+                }
+            }
+    }
+}
+```
+
+### 기존 AppGroupView 의존성 제거
+
+#### Before: 특정 화면에서만 권한 체크
+```swift
+// AppGroupMainView.swift - 기존 방식
+.modifier(AppGroupAuthModifier(viewModel: viewModel))  // 특정 화면에서만 동작
+```
+
+#### After: 앱 최상단에서 전역 관리
+```swift
+// MainAppView.swift - 개선된 방식
+.modifier(MainAuthModifier(viewModel: mainAppViewModel))  // 앱 전체에서 동작
+```
+
+## 🚀 구현 결과: 완전한 권한 변경 대응 시스템
+
+### 1. **실시간 권한 감지**
+- 앱 시작 시 자동 권한 확인
+- 포그라운드 진입 시 권한 재확인  
+- 설정에서 권한 변경 시 즉시 감지
+
+### 2. **전역 권한 요청 플로우**
+- 앱 어느 화면에서든 권한 부족 시 자동으로 권한 요청 화면 표시
+- fullScreenCover로 사용자 주의 집중
+- 권한 획득 후 자동으로 원래 화면 복귀
+
+### 3. **아키텍처 개선**
+- 기존: 특정 화면별 권한 체크 → 개선: 앱 최상단 통합 관리
+- 기존: 수동 권한 확인 → 개선: 자동 권한 상태 추적
+- 기존: 화면별 권한 UI → 개선: 재사용 가능한 권한 컴포넌트

--- a/History/#72-reauth-swiftui-view.md
+++ b/History/#72-reauth-swiftui-view.md
@@ -1,14 +1,6 @@
-//
-//  UserNotificationAuthView.swift
-//  FeatureOnboardingInterface
-//
-//  Created by Greem on 7/25/25.
-//
+## 기존 뷰 구조
 
-import SwiftUI
-import SharedDesignSystem
-import Domain
-
+``` swift
 public struct UserNotificationAuthView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(StartUpViewModel.self) var startUpViewModel
@@ -17,18 +9,87 @@ public struct UserNotificationAuthView: View {
     
     public var body: some View {
         @Bindable var viewModel = userNotificationAuthViewModel
-        UserNoficationAuth(
-            showNaivgation: true,
-            authorizationButtonAction: {
+        ZStack(alignment: .bottom) {
+            Color.grey900.ignoresSafeArea()
+            VStack(spacing: 0) {
+                BrakeNavigationView(title: {
+                    EmptyView()
+                }, leading: {
+                    BrakeNavigationButton(type: .back) {
+                        dismiss()
+                    }
+                })
+                
+                VStack(alignment: .center, spacing: 16) {
+                    VStack(alignment: .center, spacing: 0) {
+                        Text("알림 타임 권한을").frame(height: 33)
+                        Text("허용해주세요.").frame(height: 33)
+                    }
+                    .foregroundStyle(.white)
+                    .font(.pretendard(size: 22, type: .semiBold))
+                    Text("정확한 타이머 알림을 받아보세요.")
+                        .foregroundStyle(Color.grey200)
+                        .font(.pretendard(size: 16, type: .medium))
+                }
+                .padding(.top, 47)
+                Spacer()
+            }
+            
+            GeometryReader { proxy in
+                ZStack {
+                    Color.clear
+                    Image.onboarding.notification
+                        .resizable()
+                        .frame(width: proxy.size.width * 0.8373)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            LargeButtonView(
+                buttonType: .confirm,
+                title: "허용하기",
+                isActive: true
+            ) {
                 userNotificationAuthViewModel.authorizationButtonTapped()
+            }
+            .padding(.bottom, 16)
+        }
+        .toolbar(.hidden, for: .navigationBar)
+        .brakePopUp(
+            isPresented: $viewModel.notificationAuthDeniedPresent,
+            title: userNotificationAuthViewModel.notoficationAuthFailedResult?.alertTitle ?? "",
+            message: "설정에서 알람을 [ 즉시 전달 ]으로 설정해주세요.",
+            icon: .iconConfetti,
+            alertType: .confirmDoubleButton,
+            primaryButtonTitle: "설정으로 이동",
+            secondaryButtonTitle: "취소",
+            primaryAction: {
+                viewModel.notificationAuthDeniedPresent = false
+                if let url = URL(string: UIApplication.openSettingsURLString),
+                   UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
             },
-            notoficationAuthFailedResult: viewModel.notoficationAuthFailedResult,
-            notificationAuthDeniedPresent: $viewModel.notificationAuthDeniedPresent,
-            notificationAuthFailedPresent: $viewModel.notificationAuthFiledPresent
+            secondaryAction: {
+                viewModel.notificationAuthDeniedPresent = false
+            }
+        )
+        .brakePopUp(
+            isPresented: $viewModel.notificationAuthFiledPresent,
+            title: viewModel.notoficationAuthFailedResult?.alertTitle ?? "",
+            message: viewModel.notoficationAuthFailedResult?.alertDescription ?? "",
+            primaryButtonTitle: "확인",
+            primaryAction: {
+                viewModel.notificationAuthFiledPresent = false
+            }
         )
     }
 }
+```
 
+## 개선 뷰 - 인스턴스 의존성 제거
+
+> 1. 의존성 프로퍼티를 제거한 뷰 제작
+``` swift
 public struct UserNoficationAuth: View {
     @Environment(\.dismiss) private var dismiss
     let showNaivgation: Bool
@@ -131,3 +192,28 @@ public struct UserNoficationAuth: View {
         )
     }
 }
+```
+
+
+> 2. 의존성 주입 뷰 적용
+``` swift
+public struct UserNotificationAuthView: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(StartUpViewModel.self) var startUpViewModel
+    @Environment(UserNotificationAuthViewModel.self) var userNotificationAuthViewModel
+    public init() { }
+    
+    public var body: some View {
+        @Bindable var viewModel = userNotificationAuthViewModel
+        UserNoficationAuth(
+            showNaivgation: true,
+            authorizationButtonAction: {
+                userNotificationAuthViewModel.authorizationButtonTapped()
+            },
+            notoficationAuthFailedResult: viewModel.notoficationAuthFailedResult,
+            notificationAuthDeniedPresent: $viewModel.notificationAuthDeniedPresent,
+            notificationAuthFailedPresent: $viewModel.notificationAuthFiledPresent
+        )
+    }
+}
+```

--- a/Projects/App/Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy
+++ b/Projects/App/Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAppActivity</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Projects/App/Extensions/ShieldActionConfigurationExtension/PrivacyInfo.xcprivacy
+++ b/Projects/App/Extensions/ShieldActionConfigurationExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAppActivity</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Projects/App/Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy
+++ b/Projects/App/Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAppActivity</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Projects/App/Resources/PrivacyInfo.xcprivacy
+++ b/Projects/App/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <dict>
+    <key>NSPrivacyAccessedAPIType</key>
+    <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+    <key>NSPrivacyAccessedAPITypeReasons</key>
+    <array>
+-     <string>85F4.1</string>
++     <string>E174.1</string>
+    </array>
+  </dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAppActivity</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+</plist>

--- a/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
+++ b/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
@@ -15,8 +15,12 @@ public protocol UseCaseDIContainerProtocol {
     var kakaoLogInUseCase: KakaoLogInUseCase { get }
     var logInCancelUseCase: LogInCancelUseCase { get }
     var userSetNicknameUseCase: UserSetNicknameUseCase { get }
+    
     var requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase { get }
     var requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase { get }
+    var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase { get }
+    var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase { get }
+    
     var fetchAppGroupUseCase: FetchAppGroupUseCase { get }
     var upsertAppGroupUseCase: UpsertAppGroupUseCase { get }
     var deleteAppGroupUseCase: DeleteAppGroupUseCase { get }
@@ -38,6 +42,8 @@ public protocol UseCaseDIContainerProtocol {
 }
 
 public final class UseCaseDIContainer: UseCaseDIContainerProtocol {
+    
+    
     
     private let serviceContainer: ServiceDIContainerProtocol
     private let coreContainer: CoreDIContainerProtocol
@@ -74,9 +80,12 @@ public final class UseCaseDIContainer: UseCaseDIContainerProtocol {
         oAuthService: serviceContainer.oAuthLogInService
     )
     
-    @MainActor public lazy var requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase = RequestUserNotificationAuthUseCase()
+    @MainActor public private(set) lazy var requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase = RequestUserNotificationAuthUseCase()
     
-    @MainActor public lazy var requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase = RequestScreenTimeAuthUseCase()
+    @MainActor public private(set) lazy var requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase = RequestScreenTimeAuthUseCase()
+    public private(set) lazy var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase = .init()
+    
+    public private(set) lazy var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase = .init()
     
     @MainActor public lazy var fetchAppGroupUseCase: FetchAppGroupUseCase = FetchAppGroupUseCase(
         appGroupService: serviceContainer.appGroupService

--- a/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
+++ b/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
@@ -83,9 +83,9 @@ public final class UseCaseDIContainer: UseCaseDIContainerProtocol {
     @MainActor public private(set) lazy var requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase = RequestUserNotificationAuthUseCase()
     
     @MainActor public private(set) lazy var requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase = RequestScreenTimeAuthUseCase()
-    public private(set) lazy var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase = FetchUserNotificationAuthUseCase()
+    @MainActor public private(set) lazy var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase = FetchUserNotificationAuthUseCase()
     
-    public private(set) lazy var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase = FetchScreenTimeAuthUseCase()
+    @MainActor public private(set) lazy var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase = FetchScreenTimeAuthUseCase()
     
     @MainActor public lazy var fetchAppGroupUseCase: FetchAppGroupUseCase = FetchAppGroupUseCase(
         appGroupService: serviceContainer.appGroupService

--- a/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
+++ b/Projects/App/Sources/DIContainer/UseCaseDIContainer.swift
@@ -83,9 +83,9 @@ public final class UseCaseDIContainer: UseCaseDIContainerProtocol {
     @MainActor public private(set) lazy var requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase = RequestUserNotificationAuthUseCase()
     
     @MainActor public private(set) lazy var requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase = RequestScreenTimeAuthUseCase()
-    public private(set) lazy var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase = .init()
+    public private(set) lazy var fetchUserNotificationAuthUseCase: FetchUserNotificationAuthUseCase = FetchUserNotificationAuthUseCase()
     
-    public private(set) lazy var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase = .init()
+    public private(set) lazy var fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase = FetchScreenTimeAuthUseCase()
     
     @MainActor public lazy var fetchAppGroupUseCase: FetchAppGroupUseCase = FetchAppGroupUseCase(
         appGroupService: serviceContainer.appGroupService

--- a/Projects/App/Sources/Models/AuthFailed.swift
+++ b/Projects/App/Sources/Models/AuthFailed.swift
@@ -1,0 +1,15 @@
+//
+//  AuthFailed.swift
+//  Brake
+//
+//  Created by Greem on 8/12/25.
+//
+
+import Foundation
+
+enum AuthFailed: String, Identifiable {
+    var id: String { self.rawValue }
+    case screenTime
+    case notification
+    case both
+}

--- a/Projects/App/Sources/ViewModels/MainAppViewModel.swift
+++ b/Projects/App/Sources/ViewModels/MainAppViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  MainAppViewModel.swift
+//  Brake
+//
+//  Created by Greem on 8/12/25.
+//
+
+import Foundation
+import Domain
+
+@Observable
+final class MainAppViewModel {
+    var authFailedPresented: AuthFailed? = nil
+    
+    private let fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase
+    private let fetchNotificationAuthUseCase: FetchUserNotificationAuthUseCase
+    
+    init(
+        fetchScreenTimeAuthUseCase: FetchScreenTimeAuthUseCase,
+        fetchNotificationAuthUseCase: FetchUserNotificationAuthUseCase
+    ) {
+        self.fetchScreenTimeAuthUseCase = fetchScreenTimeAuthUseCase
+        self.fetchNotificationAuthUseCase = fetchNotificationAuthUseCase
+    }
+    
+    func onAppear() {
+        Task {
+            await setAuthorizationStatus()
+        }
+    }
+    
+    func sceneActive() {
+        Task {
+            await setAuthorizationStatus()
+        }
+    }
+    
+    private func setAuthorizationStatus() async {
+        let screenTimeAuthorizationResult = fetchScreenTimeAuthUseCase.execute()
+        let notificationAuthorizationResult = await fetchNotificationAuthUseCase.execute()
+        let isApprovedScreenTime =  switch screenTimeAuthorizationResult {
+            case .approved: true
+            default: false
+        }
+        let isApprovedNotification = switch notificationAuthorizationResult {
+            case .approved: true
+            default: false
+        }
+        print("screenTime: \(isApprovedScreenTime), notification: \(isApprovedNotification)")
+        await MainActor.run { [weak self] in
+            guard let self else { return }
+            if !isApprovedNotification && !isApprovedScreenTime {
+                self.authFailedPresented = .both
+            } else if !isApprovedNotification {
+                self.authFailedPresented = .notification
+            } else if !isApprovedScreenTime {
+                self.authFailedPresented = .screenTime
+            } else {
+                self.authFailedPresented = nil
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/ViewModels/MainAppViewModel.swift
+++ b/Projects/App/Sources/ViewModels/MainAppViewModel.swift
@@ -46,7 +46,7 @@ final class MainAppViewModel {
             case .approved: true
             default: false
         }
-        print("screenTime: \(isApprovedScreenTime), notification: \(isApprovedNotification)")
+        
         await MainActor.run { [weak self] in
             guard let self else { return }
             if !isApprovedNotification && !isApprovedScreenTime {

--- a/Projects/App/Sources/ViewModels/MainAppViewModel.swift
+++ b/Projects/App/Sources/ViewModels/MainAppViewModel.swift
@@ -36,7 +36,7 @@ final class MainAppViewModel {
     }
     
     private func setAuthorizationStatus() async {
-        let screenTimeAuthorizationResult = fetchScreenTimeAuthUseCase.execute()
+        let screenTimeAuthorizationResult = await fetchScreenTimeAuthUseCase.execute()
         let notificationAuthorizationResult = await fetchNotificationAuthUseCase.execute()
         let isApprovedScreenTime =  switch screenTimeAuthorizationResult {
             case .approved: true

--- a/Projects/App/Sources/Views/MainAppView.swift
+++ b/Projects/App/Sources/Views/MainAppView.swift
@@ -10,39 +10,44 @@ import SharedDesignSystem
 import FeatureOnboardingInterface
 import FeatureAppGroupFeatureInterface
 import FeatureMyInfoInterface
-import Domain
 
 struct MainAppView: View {
     @Environment(\.appDIContainer) private var appDIContainer
     @Environment(StartUpViewModel.self) var startUpViewModel
     
     var body: some View {
-        ZStack {
-            Color.grey900.ignoresSafeArea()
-            switch startUpViewModel.userLogInState {
-            case .unknown:
-                EmptyView()
-            case .logInRequired:
-                LoginView()
-                    .environment(
-                        LogInViewModel(
-                            appleLogInUseCase: appDIContainer.useCaseContainer.appleLogInUseCase,
-                            kakaoLogInUseCase: appDIContainer.useCaseContainer.kakaoLogInUseCase,
-                            logInCompleted: startUpViewModel.logInCompleted
-                        )
+       ZStack {
+           switch startUpViewModel.userLogInState {
+           case .unknown:
+               EmptyView()
+           case .logInRequired:
+               LoginView()
+                   .environment(
+                       LogInViewModel(
+                           appleLogInUseCase: appDIContainer.useCaseContainer.appleLogInUseCase,
+                           kakaoLogInUseCase: appDIContainer.useCaseContainer.kakaoLogInUseCase,
+                           logInCompleted: startUpViewModel.logInCompleted
+                       )
+                   )
+           case .onboardingRequired:
+               OnboardingView()
+                   .environment(startUpViewModel)
+           case .brakeAvailable:
+               MainTabView()
+                .environment(
+                    MainAppViewModel(
+                        fetchScreenTimeAuthUseCase: appDIContainer.useCaseContainer.fetchScreenTimeAuthUseCase,
+                        fetchNotificationAuthUseCase: appDIContainer.useCaseContainer.fetchUserNotificationAuthUseCase
                     )
-            case .onboardingRequired:
-                OnboardingView()
-                    .environment(startUpViewModel)
-            case .brakeAvailable:
-                MainTabView().environment(startUpViewModel)
-            case .errorOccured:
-                EmptyView()
-            }
-        }
-        .animation(.easeInOut(duration: 0.3), value: startUpViewModel.userLogInState)
-        .onAppear {
-            startUpViewModel.startUpOnAppear()
-        }
+                )
+                .environment(startUpViewModel)
+           case .errorOccured:
+               EmptyView()
+           }
+       }
+       .animation(.easeInOut(duration: 0.3), value: startUpViewModel.userLogInState)
+       .onAppear {
+           startUpViewModel.startUpOnAppear()
+       }
     }
 }

--- a/Projects/App/Sources/Views/MainTapView/MainAuthModifier.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainAuthModifier.swift
@@ -1,0 +1,120 @@
+//
+//  MainAuthModifier.swift
+//  Brake
+//
+//  Created by Greem on 8/12/25.
+//
+
+import Foundation
+import SwiftUI
+import Feature
+
+struct MainAuthModifier: ViewModifier {
+    @Environment(\.appDIContainer) private var appDIContainer
+    @Environment(MainAppViewModel.self) private var mainAppViewModel
+    func body(content: Content) -> some View {
+        @Bindable var viewModel = mainAppViewModel
+        content.fullScreenCover(item: $viewModel.authFailedPresented) { item in
+            switch item {
+            case .both:
+                BothAuthViewModel()
+                    .environment(mainAppViewModel)
+            case .notification:
+                MainUserNotificationAuthView(showNavigation: false)
+                    .environment(mainAppViewModel)
+                    .environment(
+                        UserNotificationAuthViewModel(
+                            requestUserNotificationAuthUseCase: appDIContainer.useCaseContainer.requestUserNotificationAuthUseCase,
+                            notificationApproved: {
+                                mainAppViewModel.authFailedPresented = nil
+                            }
+                        )
+                    )
+            case .screenTime:
+                MainScreenTimeAuthView(showNavigation: false)
+                    .environment(mainAppViewModel)
+                    .environment(
+                        ScreenTimeAuthViewModel(
+                            requestScreenTimeAuthUseCase: appDIContainer.useCaseContainer.requestScreenTimeAuthUseCase,
+                            screenTimeApproved: {
+                                mainAppViewModel.authFailedPresented = nil
+                            }
+                        )
+                    )
+            }
+        }
+    }
+    
+    struct BothAuthViewModel: View {
+        @Environment(MainAppViewModel.self) var mainAppViewModel
+        @Environment(\.appDIContainer) private var appDIContainer
+        @State private var showNotificationAuth: Bool = false
+        var body: some View {
+            NavigationStack {
+                MainScreenTimeAuthView(showNavigation: false)
+                    .navigationDestination(isPresented: $showNotificationAuth, destination: {
+                        MainUserNotificationAuthView(showNavigation: true)
+                            .environment(mainAppViewModel)
+                            .environment(
+                                UserNotificationAuthViewModel(
+                                    requestUserNotificationAuthUseCase: appDIContainer.useCaseContainer.requestUserNotificationAuthUseCase,
+                                    notificationApproved: {
+                                        mainAppViewModel.authFailedPresented = nil
+                                    }
+                                )
+                            )
+                    })
+                    .environment(mainAppViewModel)
+                    .environment(
+                        ScreenTimeAuthViewModel(
+                            requestScreenTimeAuthUseCase: appDIContainer.useCaseContainer.requestScreenTimeAuthUseCase,
+                            screenTimeApproved: {
+                                Task { @MainActor in
+                                    showNotificationAuth = true
+                                }
+                            }
+                        )
+                    )
+                    
+            }
+        }
+    }
+    
+    struct MainUserNotificationAuthView: View {
+        @Environment(MainAppViewModel.self) var mainAppViewModel
+        @Environment(UserNotificationAuthViewModel.self) var userNotificationAuthViewModel
+        @Environment(\.dismiss) var dismiss
+        let showNavigation: Bool
+        var body: some View {
+            @Bindable var viewModel = userNotificationAuthViewModel
+            UserNoficationAuth(
+                showNaivgation: showNavigation,
+                authorizationButtonAction: {
+                    viewModel.authorizationButtonTapped()
+                },
+                notoficationAuthFailedResult: userNotificationAuthViewModel.notoficationAuthFailedResult,
+                notificationAuthDeniedPresent: $viewModel.notificationAuthDeniedPresent,
+                notificationAuthFailedPresent: $viewModel.notificationAuthFiledPresent
+            )
+        }
+    }
+
+    struct MainScreenTimeAuthView: View {
+        @Environment(MainAppViewModel.self) private var mainAppViewModel
+        @Environment(ScreenTimeAuthViewModel.self) private var userNotificationAuthViewModel
+        @Environment(\.dismiss) private var dismiss
+        let showNavigation: Bool
+        var body: some View {
+            @Bindable var viewModel = userNotificationAuthViewModel
+            ScreenTimeAuth(
+                showNavigation: showNavigation,
+                authorizationButtonAction: {
+                    viewModel.authorizationButtonTapped()
+                },
+                screenTimeAuthFailedResult: userNotificationAuthViewModel.screenTimeAuthFailedResult,
+                cancelScreenTimeGrantPresented: $viewModel.cancelScreenTimeGrantPresented,
+                screenTimeAuthFailedPresent: $viewModel.screenTimeAuthFailedPresent
+            )
+        }
+    }
+}

--- a/Projects/App/Sources/Views/MainTapView/MainAuthModifier.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainAuthModifier.swift
@@ -94,7 +94,7 @@ struct MainAuthModifier: ViewModifier {
                 },
                 notoficationAuthFailedResult: userNotificationAuthViewModel.notoficationAuthFailedResult,
                 notificationAuthDeniedPresent: $viewModel.notificationAuthDeniedPresent,
-                notificationAuthFailedPresent: $viewModel.notificationAuthFiledPresent
+                notificationAuthFailedPresent: $viewModel.notificationAuthFailedPresent
             )
         }
     }

--- a/Projects/App/Sources/Views/MainTapView/MainTabView.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainTabView.swift
@@ -11,10 +11,14 @@ import FeatureAppGroupFeatureInterface
 import FeatureMyInfoInterface
 import FeatureOnboardingInterface
 
+
 struct MainTabView: View {
     @Environment(\.appDIContainer) private var appDIContainer
     @Environment(StartUpViewModel.self) var startUpViewModel
-
+    @Environment(MainAppViewModel.self) var mainAppViewModel
+    @Environment(\.scenePhase) var scenePhase
+    @Environment(\.dismiss) var dismiss
+    
     @State private var selectedTab: TabItemType = .dashboard
 
     var body: some View {
@@ -29,7 +33,14 @@ struct MainTabView: View {
                 }
             }
             
-        }.environment(
+        }
+        .onAppear() { mainAppViewModel.onAppear() }
+        .onChange(of: scenePhase, { oldValue, newValue in
+            if newValue == .active {
+                mainAppViewModel.sceneActive()
+            }
+        })
+        .environment(
             AppGroupMainViewModel(
                 fetchAppGroupUseCase: appDIContainer.useCaseContainer.fetchAppGroupUseCase,
                 requestScreenTimeAuthUseCase: appDIContainer.useCaseContainer.requestScreenTimeAuthUseCase,
@@ -53,6 +64,15 @@ struct MainTabView: View {
                 }
             )
         )
+        .mainAuthModifier().environment(mainAppViewModel)
     }
 }
+
+fileprivate extension View {
+    func mainAuthModifier() -> some View {
+        @Environment(MainAppViewModel.self) var mainAppViewModel
+        return self.modifier(MainAuthModifier())
+    }
+}
+
 

--- a/Projects/App/Sources/Views/MainTapView/MainTabView.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainTabView.swift
@@ -17,7 +17,6 @@ struct MainTabView: View {
     @Environment(StartUpViewModel.self) var startUpViewModel
     @Environment(MainAppViewModel.self) var mainAppViewModel
     @Environment(\.scenePhase) var scenePhase
-    @Environment(\.dismiss) var dismiss
     
     @State private var selectedTab: TabItemType = .dashboard
 
@@ -64,7 +63,8 @@ struct MainTabView: View {
                 }
             )
         )
-        .mainAuthModifier().environment(mainAppViewModel)
+        .mainAuthModifier()
+        .environment(mainAppViewModel)
     }
 }
 

--- a/Projects/App/Sources/Views/MainTapView/MainTabView.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainTabView.swift
@@ -42,7 +42,6 @@ struct MainTabView: View {
         .environment(
             AppGroupMainViewModel(
                 fetchAppGroupUseCase: appDIContainer.useCaseContainer.fetchAppGroupUseCase,
-                requestScreenTimeAuthUseCase: appDIContainer.useCaseContainer.requestScreenTimeAuthUseCase,
                 fetchSelectedNotificationUseCase: appDIContainer.useCaseContainer.fetchSelectedNotificationUseCase,
                 createBlockScheduleUseCase: appDIContainer.useCaseContainer.createBlockScheduleUseCase,
                 deleteBlockScheduleUseCase: appDIContainer.useCaseContainer.deleteBlockScheduleUseCase,

--- a/Projects/App/Sources/Views/MainTapView/MainTabView.swift
+++ b/Projects/App/Sources/Views/MainTapView/MainTabView.swift
@@ -62,14 +62,13 @@ struct MainTabView: View {
                 }
             )
         )
-        .mainAuthModifier()
         .environment(mainAppViewModel)
+        .mainAuthModifier()
     }
 }
 
 fileprivate extension View {
     func mainAuthModifier() -> some View {
-        @Environment(MainAppViewModel.self) var mainAppViewModel
         return self.modifier(MainAuthModifier())
     }
 }

--- a/Projects/Domain/Shared/Interface/Sources/UseCase/FetchScreenTimeAuthUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCase/FetchScreenTimeAuthUseCase.swift
@@ -13,7 +13,9 @@ public struct FetchScreenTimeAuthUseCase {
     
     public init() { }
     
-    public func execute() -> ScreenTimeAuthorizationResult {
+    public func execute() async -> ScreenTimeAuthorizationResult {
+        /// 동기 로직 처리시 notDetermined로 바로 떨어지는 엣지케이스 대응
+        try? await Task.sleep(for: .seconds(0.1))
         let status = center.authorizationStatus
         switch status {
         case .notDetermined: return .unknownError

--- a/Projects/Domain/Shared/Interface/Sources/UseCase/FetchScreenTimeAuthUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCase/FetchScreenTimeAuthUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchScreenTimeAuthUseCase.swift
+//  DomainSharedInterface
+//
+//  Created by Greem on 8/12/25.
+//
+
+import Foundation
+import FamilyControls
+
+public struct FetchScreenTimeAuthUseCase {
+    private let center: AuthorizationCenter = AuthorizationCenter.shared
+    
+    public init() { }
+    
+    public func execute() -> ScreenTimeAuthorizationResult {
+        let status = center.authorizationStatus
+        switch status {
+        case .notDetermined: return .unknownError
+        case .denied: return .denied
+        case .approved: return .approved
+        @unknown default: return .unknownError
+        }
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/UseCase/FetchUserNotificationAuthUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCase/FetchUserNotificationAuthUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchUserNotificationAuthUseCase.swift
+//  DomainSharedInterface
+//
+//  Created by Greem on 8/12/25.
+//
+
+import Foundation
+import NotificationCenter
+
+public struct FetchUserNotificationAuthUseCase {
+    
+    public init() { }
+    
+    public func execute() async -> NotificationAuthorizationResult {
+        let notificationSettings: UNNotificationSettings = await UNUserNotificationCenter.current().notificationSettings()
+        let status: UNAuthorizationStatus = notificationSettings.authorizationStatus
+        switch status {
+        case .notDetermined, .ephemeral, .provisional: return .denied
+        case .denied: return .denied
+        case .authorized: return .approved
+        @unknown default: return .unknownError
+        }
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/UseCase/RequestScreenTimeAuthUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCase/RequestScreenTimeAuthUseCase.swift
@@ -8,7 +8,6 @@
 import Foundation
 import FamilyControls
 
-// MARK: -- Domain 레이어로 내려줘야 함...
 public struct RequestScreenTimeAuthUseCase {
     private let center: AuthorizationCenter = AuthorizationCenter.shared
     
@@ -39,3 +38,5 @@ public struct RequestScreenTimeAuthUseCase {
         return .unknownError
     }
 }
+
+

--- a/Projects/Feature/AppGroupFeature/Example/Sources/AppView.swift
+++ b/Projects/Feature/AppGroupFeature/Example/Sources/AppView.swift
@@ -19,15 +19,9 @@ struct FeatureAppGroupFeatureApp: App {
 
     var body: some Scene {
         WindowGroup {
-            BrakeTabView(selectedTab: $selectedTab, isTabBarHidden: $isTabBarHidden) { selectedTab in
+            BrakeTabView(selectedTab: $selectedTab) { selectedTab in
                 ZStack {
                     switch selectedTab {
-                    case .report:
-                        VStack {
-                            Spacer()
-                            Text("Report")
-                            Spacer()
-                        }
                     case .dashboard:
                         AppGroupMainView()
                     case .myInfo:
@@ -43,7 +37,6 @@ struct FeatureAppGroupFeatureApp: App {
             .environment(
                 AppGroupMainViewModel(
                     fetchAppGroupUseCase: diContainer.fetchAppGroupUseCase,
-                    requestScreenTimeAuthUseCase: diContainer.requestScreenTimeAuthUseCase,
                     fetchSelectedNotificationUseCase: diContainer.fetchSelectedNotificationUseCase,
                     createBlockScheduleUseCase: diContainer.createBlockScheduleUseCase,
                     deleteBlockScheduleUseCase: diContainer.deleteBlockScheduleUseCase,

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
@@ -16,6 +16,7 @@ public struct AppGroupMainView: View {
     @Environment(\.appGroupDIContainer) private var diContainer
     @Environment(AppGroupMainViewModel.self) private var appGroupMainViewModel
     @Environment(\.scenePhase) var scenePhase
+    
     public init() { }
     public var body: some View {
         NavigationStack {
@@ -94,36 +95,6 @@ public struct AppGroupMainView: View {
     }
 }
 
-fileprivate extension ScreenTimeAuthorizationResult {
-    var title: String {
-        switch self {
-        case .denied: "스크린타임 권한이 거부되었습니다"
-        case .restricted: "스크린타임 기능이 제한되었습니다"
-        case .unavailableDevice: "지원하지 않는 기기입니다"
-        case .userCancel: "스크린타임 권한이 필요합니다"
-        case .approved: ""
-        case .unknownError, .authenticationMethodUnavailable: "인증 중 오류가 발생했습니다"
-        case .networkError: "네트워크 연결을 확인해주세요"
-        }
-    }
-    var desc: String {
-        switch self {
-        case .denied: "설정에서 스크린타임 권한을 허용해주세요"
-        case .restricted: "부모님의 허가가 필요합니다"
-        case .unavailableDevice: "이 기기에서는 스크린타임 기능을 사용할 수 없습니다"
-        case .userCancel: "앱 사용 제한 기능을 사용하려면 권한이 필요합니다"
-        case .approved: ""
-        case .unknownError, .authenticationMethodUnavailable, .networkError: "잠시 후 다시 시도해주세요"
-        }
-    }
-    
-    var primaryButtonTitle: String {
-        switch self {
-        case .denied, .unknownError, .userCancel, .approved, .authenticationMethodUnavailable, .networkError: "다시 시도하기"
-        case .restricted, .unavailableDevice: "확인"
-        }
-    }
-}
 
 
 fileprivate extension AppGroupMainView {

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
@@ -51,7 +51,7 @@ public struct AppGroupMainView: View {
                     bottomPadding: 60
                 )
                 .fullScreenCover(
-                    isPresented:  $viewModel.appBrakeTimeSettingPresent,
+                    isPresented: $viewModel.appBrakeTimeSettingPresent,
                     content: {
                         AppBrakeTimeSettingView()
                             .environment(
@@ -79,26 +79,6 @@ public struct AppGroupMainView: View {
             }
             
         }
-        .brakePopUp(
-            isPresented: Binding(
-                get: { appGroupMainViewModel.screenTimeAuthAlertPresent } ,
-                set: { appGroupMainViewModel.screenTimeAuthAlertPresent = $0 }
-            ),
-            title: appGroupMainViewModel.screenTimeAuthErrorResult?.title ?? "스크린타임 권한 오류",
-            message: appGroupMainViewModel.screenTimeAuthErrorResult?.desc ?? "스크린타임 권한 처리 중 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
-            primaryButtonTitle: appGroupMainViewModel.screenTimeAuthErrorResult?.primaryButtonTitle ?? "확인",
-            primaryAction: {
-                guard let result = appGroupMainViewModel.screenTimeAuthErrorResult else {
-                    appGroupMainViewModel.screenTimeAuthAlertPresent = false
-                    return
-                }
-                switch result {
-                case .denied, .unknownError, .userCancel, .approved, .authenticationMethodUnavailable, .networkError:
-                    appGroupMainViewModel.reAuthButtonTapped()
-                case .restricted, .unavailableDevice: break
-                }
-            }
-        )
         .onChange(of: scenePhase, { oldValue, newValue in
             switch newValue {
             case .inactive: self.appGroupMainViewModel.setScene(.inActive)

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/View/AppGroupMainView/AppGroupMainView.swift
@@ -96,7 +96,6 @@ public struct AppGroupMainView: View {
 }
 
 
-
 fileprivate extension AppGroupMainView {
     func createUpsertAppGroupViewModel() -> UpsertAppGroupViewModel {
         UpsertAppGroupViewModel(

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
@@ -67,7 +67,6 @@ public final class AppGroupMainViewModel {
     private var timerTask: Task<(), Never>?
     
     private let fetchAppGroupUseCase: FetchAppGroupUseCase
-    private let requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase
     private let fetchSelectedNotificationUseCase: FetchSelectedNotificationUseCaseProtocol
     
     private let createBlockScheduleUseCase: CreateBlockScheduleUseCaseProtocol
@@ -84,7 +83,6 @@ public final class AppGroupMainViewModel {
     
     public init(
         fetchAppGroupUseCase: FetchAppGroupUseCase,
-        requestScreenTimeAuthUseCase: RequestScreenTimeAuthUseCase,
         fetchSelectedNotificationUseCase: FetchSelectedNotificationUseCaseProtocol,
         createBlockScheduleUseCase: CreateBlockScheduleUseCaseProtocol,
         deleteBlockScheduleUseCase: DeleteBlockScheduleUseCaseProtocol,
@@ -94,10 +92,7 @@ public final class AppGroupMainViewModel {
         endBreakTimeUseCase: EndBreakTimeUseCaseProtocol
     ) {
         self.fetchAppGroupUseCase = fetchAppGroupUseCase
-        self.requestScreenTimeAuthUseCase = requestScreenTimeAuthUseCase
         self.fetchSelectedNotificationUseCase = fetchSelectedNotificationUseCase
-        
-        
         self.createBlockScheduleUseCase = createBlockScheduleUseCase
         self.deleteBlockScheduleUseCase = deleteBlockScheduleUseCase
         self.fetchBlockScheduleUseCase = fetchBlockScheduleUseCase

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
@@ -45,7 +45,6 @@ public final class AppGroupMainViewModel {
     var toastMessage: String? = nil
     
     
-    var screenTimeAuthAlertPresent: Bool = false
     var brakeTimeSettingCompletePresent: Bool = false
     var screenTimeAuthErrorResult: ScreenTimeAuthorizationResult? = nil
     
@@ -142,7 +141,6 @@ public final class AppGroupMainViewModel {
 
     private func sceneActive() {
         self.brakeStatus = self.brakeStatusStorage
-        Task(priority: .background) { await screenTimeAuthRequest() }
         Task(priority: .high) {
             if let appGroup = try await fetchAppGroupUseCase.execute(),
                let schedule: BlockScheduleEntity = fetchBlockScheduleUseCase.execute(activityName: "\(appGroup.groupID)") {
@@ -202,11 +200,6 @@ public final class AppGroupMainViewModel {
         }
     }
 
-    public func reAuthButtonTapped() {
-        Task {
-            await screenTimeAuthRequest()
-        }
-    }
     
     public func sessionExitButtonTapped() {
         self.sessionExitAlertPresent = true
@@ -342,17 +335,6 @@ public final class AppGroupMainViewModel {
 
 // MARK: - Private Helper Methods
 fileprivate extension AppGroupMainViewModel {
-    func screenTimeAuthRequest() async {
-        let result: ScreenTimeAuthorizationResult = await requestScreenTimeAuthUseCase.execute()
-        await MainActor.run { [weak self] in
-            guard let self else { return }
-            self.screenTimeAuthErrorResult = result
-            switch result {
-            case .approved: screenTimeAuthAlertPresent = false
-            default: screenTimeAuthAlertPresent = true
-            }
-        }
-    }
 
     func toast(message: String) {
         self.toastTask?.cancel()

--- a/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
+++ b/Projects/Feature/AppGroupFeature/Interface/Sources/ViewModel/AppGroupMainViewModel.swift
@@ -17,6 +17,7 @@ extension AppGroup: @retroactive Identifiable, @retroactive Equatable {
         lhs.id == rhs.id
     }
 }
+
 public enum AppScene {
     case active
     case inActive

--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -19,6 +19,7 @@ struct OnboardingExampleApp: App {
     init() { }
     var body: some Scene {
         WindowGroup {
+            
             StartUpView()
                 .environment(
                     StartUpViewModel(
@@ -29,6 +30,40 @@ struct OnboardingExampleApp: App {
         }
     }
     
+    @ViewBuilder
+    var screenTimeAuth: some View {
+        ScreenTimeAuthView()
+            .environment(
+                StartUpViewModel(
+                    autoLogInUseCase: diContainer.autoLogInUseCase,
+                    onboardingStateUseCase: diContainer.onboardingStateUseCase
+                )
+            )
+            .environment(
+                ScreenTimeAuthViewModel(requestScreenTimeAuthUseCase: diContainer.requestScreenTimeAuthUseCase, screenTimeApproved: {
+                    print("안전하게 처리!!")
+                })
+            )
+    }
+    
+    @ViewBuilder
+    var userNotificationAuth: some View {
+        UserNotificationAuthView()
+            .environment(
+                StartUpViewModel(
+                    autoLogInUseCase: diContainer.autoLogInUseCase,
+                    onboardingStateUseCase: diContainer.onboardingStateUseCase
+                )
+            )
+            .environment(
+                UserNotificationAuthViewModel(
+                    requestUserNotificationAuthUseCase: diContainer.requestUserNotificationAuthUseCase,
+                    notificationApproved: {
+                        print("스크린타임 허용함")
+                    }
+                )
+            )
+    }
 }
 
 struct StartUpView: View {

--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -19,7 +19,6 @@ struct OnboardingExampleApp: App {
     init() { }
     var body: some Scene {
         WindowGroup {
-//            userNotificationAuth
             StartUpView()
                 .environment(
                     StartUpViewModel(

--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -19,7 +19,7 @@ struct OnboardingExampleApp: App {
     init() { }
     var body: some Scene {
         WindowGroup {
-            
+//            userNotificationAuth
             StartUpView()
                 .environment(
                     StartUpViewModel(

--- a/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
@@ -18,6 +18,7 @@ public struct ScreenTimeAuthView: View {
     public init() { }
     
     public var body: some View {
+        @Bindable var viewModel = screenTimeAuthViewModel
         ZStack(alignment: .bottom) {
             Color.grey900.ignoresSafeArea()
             VStack(spacing: 0) {
@@ -43,8 +44,6 @@ public struct ScreenTimeAuthView: View {
                 Spacer()
             }
             
-            
-            
             GeometryReader { proxy in
                 ZStack {
                     Color.clear
@@ -54,7 +53,6 @@ public struct ScreenTimeAuthView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            
             LargeButtonView(
                 buttonType: .confirm,
                 title: "허용하기",
@@ -65,41 +63,26 @@ public struct ScreenTimeAuthView: View {
             .padding(.bottom, 16)
         }
         .toolbar(.hidden, for: .navigationBar)
-        .alert(isPresented: .init(get: {
-            screenTimeAuthViewModel.cancelScreenTimeGrantPresented
-        }, set: {
-            screenTimeAuthViewModel.cancelScreenTimeGrantPresented = $0
-        }), content: {
-            VStack(spacing: 20) {
-                Text("Brake Alert").font(.title)
-                VStack {
-                    Text("여기에 추가적인 콘텐츠를 넣으세요")
-                    Button {
-                        self.screenTimeAuthViewModel.cancelScreenTimeGrantPresented = false
-                    } label: {
-                        Text("Dismiss")
-                    }
-                }
+        .brakePopUp(
+            isPresented: $viewModel.cancelScreenTimeGrantPresented,
+            title: "스크린타임 권한이 필요해요",
+            message: "Brake!의 기능을 사용하기 위해서는\n스크린타임 연동이 필수적이에요.",
+            icon: .iconConfetti,
+            primaryButtonTitle: "확인",
+            primaryBackgroundColor: .brakeYellow,
+            primaryAction: {
+                viewModel.cancelScreenTimeGrantPresented = false
             }
-            .padding(15)
-            .background(.background, in: .rect(cornerRadius: 10))
-            .transition(.blurReplace)
-        }, background: {
-            Rectangle().fill(.primary.opacity(0.35))
-        })
-        .alert(
-            screenTimeAuthViewModel.screenTimeAuthFailedResult?.alertTitle ?? "",
-            isPresented: .init(get: {
-                screenTimeAuthViewModel.screenTimeAuthFailedPresent
-            }, set: {
-                screenTimeAuthViewModel.screenTimeAuthFailedPresent = $0
-            }),
-            presenting: screenTimeAuthViewModel.screenTimeAuthFailedResult,
-            actions: { result in
-                Button("확인", role: .cancel, action: {})
-            },
-            message: { result in
-                Text(result.alertDescription)
+        )
+        .brakePopUp(
+            isPresented: $viewModel.screenTimeAuthFailedPresent,
+            title: viewModel.screenTimeAuthFailedResult?.alertTitle ?? "",
+            message: viewModel.screenTimeAuthFailedResult?.alertDescription ?? "",
+            icon: .iconConfetti,
+            primaryButtonTitle: "확인",
+            primaryBackgroundColor: .brakeYellow,
+            primaryAction: {
+                viewModel.screenTimeAuthFailedPresent = false
             }
         )
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
@@ -19,16 +19,123 @@ public struct ScreenTimeAuthView: View {
     
     public var body: some View {
         @Bindable var viewModel = screenTimeAuthViewModel
+        ScreenTimeAuth(
+            showNavigation: true,
+            authorizationButtonAction: {
+                viewModel.authorizationButtonTapped()
+            },
+            screenTimeAuthFailedResult: viewModel.screenTimeAuthFailedResult,
+            cancelScreenTimeGrantPresented: $viewModel.cancelScreenTimeGrantPresented,
+            screenTimeAuthFailedPresent: $viewModel.screenTimeAuthFailedPresent
+        )
+//        ZStack(alignment: .bottom) {
+//            Color.grey900.ignoresSafeArea()
+//            VStack(spacing: 0) {
+//                BrakeNavigationView(title: {
+//                    EmptyView()
+//                }, leading: {
+//                    BrakeNavigationButton(type: .back) {
+//                        dismiss()
+//                    }
+//                })
+//                VStack(alignment: .center, spacing: 16) {
+//                    VStack(alignment: .center, spacing: 0) {
+//                        Text("스크린 타임 권한을").frame(height: 33)
+//                        Text("허용해주세요.").frame(height: 33)
+//                    }
+//                    .foregroundStyle(.white)
+//                    .font(.pretendard(size: 22, type: .semiBold))
+//                    Text("앱 사용량을 모니터링해요.")
+//                        .foregroundStyle(Color.grey200)
+//                        .font(.pretendard(size: 16, type: .medium))
+//                }
+//                .padding(.top, 47)
+//                Spacer()
+//            }
+//            
+//            GeometryReader { proxy in
+//                ZStack {
+//                    Color.clear
+//                    Image.onboarding.screentime
+//                        .resizable()
+//                        .frame(width: proxy.size.width * 0.688)
+//                        .fixedSize(horizontal: false, vertical: true)
+//                }
+//            }
+//            LargeButtonView(
+//                buttonType: .confirm,
+//                title: "허용하기",
+//                isActive: true
+//            ) {
+//                screenTimeAuthViewModel.authorizationButtonTapped()
+//            }
+//            .padding(.bottom, 16)
+//        }
+//        .toolbar(.hidden, for: .navigationBar)
+//        .brakePopUp(
+//            isPresented: $viewModel.cancelScreenTimeGrantPresented,
+//            title: "스크린타임 권한이 필요해요",
+//            message: "Brake!의 기능을 사용하기 위해서는\n스크린타임 연동이 필수적이에요.",
+//            icon: .iconConfetti,
+//            primaryButtonTitle: "확인",
+//            primaryBackgroundColor: .brakeYellow,
+//            primaryAction: {
+//                viewModel.cancelScreenTimeGrantPresented = false
+//            }
+//        )
+//        .brakePopUp(
+//            isPresented: $viewModel.screenTimeAuthFailedPresent,
+//            title: viewModel.screenTimeAuthFailedResult?.alertTitle ?? "",
+//            message: viewModel.screenTimeAuthFailedResult?.alertDescription ?? "",
+//            icon: .iconConfetti,
+//            primaryButtonTitle: "확인",
+//            primaryBackgroundColor: .brakeYellow,
+//            primaryAction: {
+//                viewModel.screenTimeAuthFailedPresent = false
+//            }
+//        )
+    }
+}
+
+
+public struct ScreenTimeAuth: View {
+    @Environment(\.dismiss) var dismiss
+    let showNavigation: Bool
+    let authorizationButtonAction: () -> Void
+    let screenTimeAuthFailedResult: ScreenTimeAuthorizationResult?
+    @Binding var cancelScreenTimeGrantPresented: Bool
+    @Binding var screenTimeAuthFailedPresent: Bool
+    
+    public init(
+        showNavigation: Bool,
+        authorizationButtonAction: @escaping () -> Void,
+        screenTimeAuthFailedResult: ScreenTimeAuthorizationResult?,
+        cancelScreenTimeGrantPresented: Binding<Bool>,
+        screenTimeAuthFailedPresent: Binding<Bool>
+    ) {
+        self.showNavigation = showNavigation
+        self.authorizationButtonAction = authorizationButtonAction
+        self.screenTimeAuthFailedResult = screenTimeAuthFailedResult
+        self._cancelScreenTimeGrantPresented = cancelScreenTimeGrantPresented
+        self._screenTimeAuthFailedPresent = screenTimeAuthFailedPresent
+    }
+    
+    public var body: some View {
         ZStack(alignment: .bottom) {
             Color.grey900.ignoresSafeArea()
             VStack(spacing: 0) {
-                BrakeNavigationView(title: {
-                    EmptyView()
-                }, leading: {
-                    BrakeNavigationButton(type: .back) {
-                        dismiss()
-                    }
-                })
+                if showNavigation {
+                    BrakeNavigationView(title: {
+                        EmptyView()
+                    }, leading: {
+                        BrakeNavigationButton(type: .back) {
+                            dismiss()
+                        }
+                    })
+                } else {
+                    Rectangle().fill(.clear).frame(height: 56)
+                }
+                
                 VStack(alignment: .center, spacing: 16) {
                     VStack(alignment: .center, spacing: 0) {
                         Text("스크린 타임 권한을").frame(height: 33)
@@ -58,31 +165,31 @@ public struct ScreenTimeAuthView: View {
                 title: "허용하기",
                 isActive: true
             ) {
-                screenTimeAuthViewModel.authorizationButtonTapped()
+                authorizationButtonAction()
             }
             .padding(.bottom, 16)
         }
         .toolbar(.hidden, for: .navigationBar)
         .brakePopUp(
-            isPresented: $viewModel.cancelScreenTimeGrantPresented,
+            isPresented: $cancelScreenTimeGrantPresented,
             title: "스크린타임 권한이 필요해요",
             message: "Brake!의 기능을 사용하기 위해서는\n스크린타임 연동이 필수적이에요.",
             icon: .iconConfetti,
             primaryButtonTitle: "확인",
             primaryBackgroundColor: .brakeYellow,
             primaryAction: {
-                viewModel.cancelScreenTimeGrantPresented = false
+                cancelScreenTimeGrantPresented = false
             }
         )
         .brakePopUp(
-            isPresented: $viewModel.screenTimeAuthFailedPresent,
-            title: viewModel.screenTimeAuthFailedResult?.alertTitle ?? "",
-            message: viewModel.screenTimeAuthFailedResult?.alertDescription ?? "",
+            isPresented: $screenTimeAuthFailedPresent,
+            title: screenTimeAuthFailedResult?.alertTitle ?? "",
+            message: screenTimeAuthFailedResult?.alertDescription ?? "",
             icon: .iconConfetti,
             primaryButtonTitle: "확인",
             primaryBackgroundColor: .brakeYellow,
             primaryAction: {
-                viewModel.screenTimeAuthFailedPresent = false
+                screenTimeAuthFailedPresent = false
             }
         )
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/ScreenTimeAuthView.swift
@@ -10,10 +10,8 @@ import Domain
 import SharedDesignSystem
 
 public struct ScreenTimeAuthView: View {
-    @Environment(\.dismiss) private var dismiss
     @Environment(StartUpViewModel.self) private var startUpViewModel
     @Environment(ScreenTimeAuthViewModel.self) private var screenTimeAuthViewModel
-    
     
     public init() { }
     
@@ -28,72 +26,6 @@ public struct ScreenTimeAuthView: View {
             cancelScreenTimeGrantPresented: $viewModel.cancelScreenTimeGrantPresented,
             screenTimeAuthFailedPresent: $viewModel.screenTimeAuthFailedPresent
         )
-//        ZStack(alignment: .bottom) {
-//            Color.grey900.ignoresSafeArea()
-//            VStack(spacing: 0) {
-//                BrakeNavigationView(title: {
-//                    EmptyView()
-//                }, leading: {
-//                    BrakeNavigationButton(type: .back) {
-//                        dismiss()
-//                    }
-//                })
-//                VStack(alignment: .center, spacing: 16) {
-//                    VStack(alignment: .center, spacing: 0) {
-//                        Text("스크린 타임 권한을").frame(height: 33)
-//                        Text("허용해주세요.").frame(height: 33)
-//                    }
-//                    .foregroundStyle(.white)
-//                    .font(.pretendard(size: 22, type: .semiBold))
-//                    Text("앱 사용량을 모니터링해요.")
-//                        .foregroundStyle(Color.grey200)
-//                        .font(.pretendard(size: 16, type: .medium))
-//                }
-//                .padding(.top, 47)
-//                Spacer()
-//            }
-//            
-//            GeometryReader { proxy in
-//                ZStack {
-//                    Color.clear
-//                    Image.onboarding.screentime
-//                        .resizable()
-//                        .frame(width: proxy.size.width * 0.688)
-//                        .fixedSize(horizontal: false, vertical: true)
-//                }
-//            }
-//            LargeButtonView(
-//                buttonType: .confirm,
-//                title: "허용하기",
-//                isActive: true
-//            ) {
-//                screenTimeAuthViewModel.authorizationButtonTapped()
-//            }
-//            .padding(.bottom, 16)
-//        }
-//        .toolbar(.hidden, for: .navigationBar)
-//        .brakePopUp(
-//            isPresented: $viewModel.cancelScreenTimeGrantPresented,
-//            title: "스크린타임 권한이 필요해요",
-//            message: "Brake!의 기능을 사용하기 위해서는\n스크린타임 연동이 필수적이에요.",
-//            icon: .iconConfetti,
-//            primaryButtonTitle: "확인",
-//            primaryBackgroundColor: .brakeYellow,
-//            primaryAction: {
-//                viewModel.cancelScreenTimeGrantPresented = false
-//            }
-//        )
-//        .brakePopUp(
-//            isPresented: $viewModel.screenTimeAuthFailedPresent,
-//            title: viewModel.screenTimeAuthFailedResult?.alertTitle ?? "",
-//            message: viewModel.screenTimeAuthFailedResult?.alertDescription ?? "",
-//            icon: .iconConfetti,
-//            primaryButtonTitle: "확인",
-//            primaryBackgroundColor: .brakeYellow,
-//            primaryAction: {
-//                viewModel.screenTimeAuthFailedPresent = false
-//            }
-//        )
     }
 }
 

--- a/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/UserNotificationAuthView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/UserNotificationAuthView.swift
@@ -24,7 +24,7 @@ public struct UserNotificationAuthView: View {
             },
             notoficationAuthFailedResult: viewModel.notoficationAuthFailedResult,
             notificationAuthDeniedPresent: $viewModel.notificationAuthDeniedPresent,
-            notificationAuthFailedPresent: $viewModel.notificationAuthFiledPresent
+            notificationAuthFailedPresent: $viewModel.notificationAuthFailedPresent
         )
     }
 }

--- a/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/UserNotificationAuthView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/View/Onboarding/UserNotificationAuthView.swift
@@ -16,6 +16,7 @@ public struct UserNotificationAuthView: View {
     public init() { }
     
     public var body: some View {
+        @Bindable var viewModel = userNotificationAuthViewModel
         ZStack(alignment: .bottom) {
             Color.grey900.ignoresSafeArea()
             VStack(spacing: 0) {
@@ -51,8 +52,6 @@ public struct UserNotificationAuthView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            
-            
             LargeButtonView(
                 buttonType: .confirm,
                 title: "허용하기",
@@ -63,32 +62,32 @@ public struct UserNotificationAuthView: View {
             .padding(.bottom, 16)
         }
         .toolbar(.hidden, for: .navigationBar)
-        .alert(
-            userNotificationAuthViewModel.notoficationAuthFailedResult?.alertTitle ?? "",
-            isPresented: .init(get: {
-                userNotificationAuthViewModel.notificationAuthFiledPresent
-            }, set: {
-                userNotificationAuthViewModel.notificationAuthFiledPresent = $0
-            }),
-            presenting: userNotificationAuthViewModel.notoficationAuthFailedResult,
-            actions: { result in
-                switch result {
-                case .denied:
-                    Button("설정으로 이동") {
-                        if let url = URL(string: UIApplication.openSettingsURLString),
-                           UIApplication.shared.canOpenURL(url) {
-                            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                        }
-                    }
-                    Button("취소", role: .cancel) {
-                    }
-                case .unknownError, .userRestricted, .approved:
-                    Button("확인", role: .cancel) {
-                    }
+        .brakePopUp(
+            isPresented: $viewModel.notificationAuthDeniedPresent,
+            title: userNotificationAuthViewModel.notoficationAuthFailedResult?.alertTitle ?? "",
+            message: "설정에서 알람을 [ 즉시 전달 ]으로 설정해주세요.",
+            icon: .iconConfetti,
+            alertType: .confirmDoubleButton,
+            primaryButtonTitle: "설정으로 이동",
+            secondaryButtonTitle: "취소",
+            primaryAction: {
+                viewModel.notificationAuthDeniedPresent = false
+                if let url = URL(string: UIApplication.openSettingsURLString),
+                   UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }
             },
-            message: { result in
-                Text(result.alertDescription)
+            secondaryAction: {
+                viewModel.notificationAuthDeniedPresent = false
+            }
+        )
+        .brakePopUp(
+            isPresented: $viewModel.notificationAuthFiledPresent,
+            title: viewModel.notoficationAuthFailedResult?.alertTitle ?? "",
+            message: viewModel.notoficationAuthFailedResult?.alertDescription ?? "",
+            primaryButtonTitle: "확인",
+            primaryAction: {
+                viewModel.notificationAuthFiledPresent = false
             }
         )
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
@@ -30,6 +30,7 @@ extension NotificationAuthorizationResult {
 public final class UserNotificationAuthViewModel {
     
     public var notificationAuthFiledPresent: Bool = false
+    public var notificationAuthDeniedPresent: Bool = false
     public var notoficationAuthFailedResult: NotificationAuthorizationResult?
     
     private let requestUserNotificationAuthUseCase: RequestUserNotificationAuthUseCase
@@ -51,7 +52,10 @@ public final class UserNotificationAuthViewModel {
                 switch result {
                 case .approved:
                     notificationApproved()
-                case .denied, .userRestricted, .unknownError:
+                case .denied:
+                    self.notificationAuthDeniedPresent = true
+                    self.notoficationAuthFailedResult = result
+                case .userRestricted, .unknownError:
                     self.notoficationAuthFailedResult = result
                     self.notificationAuthFiledPresent = true
                 }

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
@@ -29,7 +29,7 @@ extension NotificationAuthorizationResult {
 @Observable
 public final class UserNotificationAuthViewModel {
     
-    public var notificationAuthFiledPresent: Bool = false
+    public var notificationAuthFailedPresent: Bool = false
     public var notificationAuthDeniedPresent: Bool = false
     public var notoficationAuthFailedResult: NotificationAuthorizationResult?
     
@@ -57,7 +57,7 @@ public final class UserNotificationAuthViewModel {
                     self.notoficationAuthFailedResult = result
                 case .userRestricted, .unknownError:
                     self.notoficationAuthFailedResult = result
-                    self.notificationAuthFiledPresent = true
+                    self.notificationAuthFailedPresent = true
                 }
             }
         }
@@ -65,7 +65,7 @@ public final class UserNotificationAuthViewModel {
 //    
     public func userDeniedCancelTapped() {
         self.notoficationAuthFailedResult = .userRestricted
-        self.notificationAuthFiledPresent = true
+        self.notificationAuthFailedPresent = true
     }
 }
 

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewModel/Onboarding/UserNotificationAuthViewModel.swift
@@ -62,7 +62,7 @@ public final class UserNotificationAuthViewModel {
             }
         }
     }
-    
+//    
     public func userDeniedCancelTapped() {
         self.notoficationAuthFailedResult = .userRestricted
         self.notificationAuthFiledPresent = true

--- a/Tuist/ProjectDescriptionHelpers/Target+Templates/Target+App.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Templates/Target+App.swift
@@ -23,7 +23,7 @@ public extension Target {
             newFactory.product = .app
             newFactory.name = Project.Environment.targetName(deploymentTarget: deploymentTarget)
             newFactory.bundleId = Project.Environment.bundleId(deploymentTarget: deploymentTarget)
-            newFactory.resources = ["Resources/**"]
+            newFactory.resources = ["Resources/**", "Resources/PrivacyInfo.xcprivacy"]
             newFactory.productName = Project.Environment.targetName(deploymentTarget: deploymentTarget)
             newFactory.sources = .sources
             newFactory.entitlements = "\(Project.Environment.appName).entitlements"
@@ -33,6 +33,7 @@ public extension Target {
             newFactory.name = "\(Project.Environment.appName)DeviceActivityMonitorExtension-\(deploymentTarget.rawValue.capitalized)"
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: deploymentTarget)).DeviceActivityMonitorExtension"
             newFactory.sources = .mainAppDeviceActivityMonitorExtensionSources
+            newFactory.resources = ["Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy"]
             newFactory.entitlements = "Extensions/DeviceActivityMonitorExtension/BrakeDeviceActivityMonitorExtension.entitlements"
             newFactory.infoPlist = .extendingDefault(with: [
                 "CFBundleShortVersionString": deploymentTarget == .debug ? "1" : "1.0",
@@ -54,7 +55,7 @@ public extension Target {
             newFactory.name = "\(Project.Environment.appName)ShieldConfigurationExtension-\(deploymentTarget.rawValue.capitalized)"
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: deploymentTarget)).ShieldConfigurationExtension"
             newFactory.sources = .mainAppShieldConfigurationExtensionSources
-            newFactory.resources = ["Extensions/ShieldConfigurationExtension/Resources/Images.xcassets/**"]
+            newFactory.resources = ["Extensions/ShieldConfigurationExtension/Resources/Images.xcassets/**", "Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy"]
             newFactory.infoPlist = .extendingDefault(with: [
                 "CFBundleShortVersionString": deploymentTarget == .debug ? "1" : "1.0",
                 "CFBundleVersion": deploymentTarget == .debug ? "1" : "1",
@@ -70,6 +71,7 @@ public extension Target {
             newFactory.name = "\(Project.Environment.appName)ShieldActionConfigurationExtension-\(deploymentTarget.rawValue.capitalized)"
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: deploymentTarget)).ShieldActionConfigurationExtension"
             newFactory.sources = .mainAppShieldActionConfigurationExtensionSources
+            newFactory.resources = ["Extensions/ShieldActionConfigurationExtension/PrivacyInfo.xcprivacy"]
             newFactory.infoPlist = .extendingDefault(with: [
                 "CFBundleShortVersionString": deploymentTarget == .debug ? "1" : "1.0",
                 "CFBundleVersion": deploymentTarget == .debug ? "1" : "1",
@@ -100,23 +102,25 @@ public extension Target {
             newFactory.name = factory.name.isEmpty ? "\(Project.Environment.appName)NotificationExtension" : factory.name
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: .debug)).notification"
             newFactory.sources = .notificationExtensionSources
-            newFactory.resources = ["Resources/**"]
+            newFactory.resources = ["Resources/**", "Extensions/NotificationExtension/PrivacyInfo.xcprivacy"]
         case .ShieldConfigurationExtension:
             newFactory.product = .appExtension
             newFactory.name = factory.name.isEmpty ? "\(Project.Environment.appName)ShieldConfigurationExtension" : factory.name
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: .debug)).ShieldConfigurationExtension"
             newFactory.sources = .shieldConfigurationExtensionSources
-            newFactory.resources = ["Extensions/ShieldConfigurationExtension/Resources/Images.xcassets/**"]
+            newFactory.resources = ["Extensions/ShieldConfigurationExtension/Resources/Images.xcassets/**", "Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy"]
         case .ShieldActionConfigurationExtension:
             newFactory.product = .appExtension
             newFactory.name = factory.name.isEmpty ? "\(Project.Environment.appName)ShieldActionConfigurationExtension" : factory.name
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: .debug)).ShieldActionConfigurationExtension"
             newFactory.sources = .shieldActionConfigurationExtensionSources
+            newFactory.resources = ["Extensions/ShieldActionConfigurationExtension/PrivacyInfo.xcprivacy"]
         case .DeviceActivityMonitorExtension:
             newFactory.product = .appExtension
             newFactory.name = factory.name.isEmpty ? "\(Project.Environment.appName)DeviceActivityMonitorExtension" : factory.name
             newFactory.bundleId = "\(Project.Environment.bundleId(deploymentTarget: .debug)).DeviceActivityMonitorExtension"
             newFactory.sources = .mainAppDeviceActivityMonitorExtensionSources
+            newFactory.resources = ["Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy"]
             newFactory.entitlements = "Extensions/DeviceActivityMonitorExtension/BrakeDeviceActivityMonitorExtension.entitlements"
             newFactory.infoPlist = "Extensions/DeviceActivityMonitorExtension/Info.plist"
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!--  ex) #이슈번호, #이슈번호 -->
close #72 
## 📝 작업 내용

- 온보딩 권한 확인 Brake 팝업 뷰 적용
- 메인 앱 최상단 권한 확인 Shield 적용
- 현재 권한 상태 확인을 위한 FetchUserNotificationAuthUseCase / FetchScreenTimeAuthUseCase 추가
- 기존 AppGroup Feature > AppGroupMainView에서 권한 확인 처리 제거

## 🧪 테스트 케이스 (Optional)

- 스크린 타임 권한 요청 플로우 검사, navigation back 확인 
- 메인 앱 최상단 권한 변경 분기 처리 - both, screentime, notification
- 기존 AppGroupMainView 권한 확인 처리 제거 확인
-
## 📷 결과 (Optional)

| 알 수 없는 오류 | 스크린타임 권한 재요청 | 노티 권한 재요청 |
|--|--|--|
|<img src="https://github.com/user-attachments/assets/03b6eda8-d9b5-4a08-8805-589d781a4bd5" width="250">|<img src="https://github.com/user-attachments/assets/f6785246-cf20-476e-ae13-0d62e04b5a27" width="250">|<img src="https://github.com/user-attachments/assets/8190c849-21b6-4f3a-8dc7-43ef56d937a1" width="250">|

<img src="https://github.com/user-attachments/assets/451519f2-0ae5-4a67-bdc6-b598d1fbeb6f" width="320">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 앱 전역 권한 관리 도입으로 알림·스크린타임 허용 상태를 중앙에서 관찰.
  - 전체화면 권한 안내 플로우 자동 표시(앱 전역 프롬프트).
  - 재사용 가능한 권한 UI 컴포넌트 추가(알림·스크린타임).

- **변경 사항**
  - 앱 시작 및 포그라운드 진입 시 권한 상태 자동 갱신.
  - 개별 화면 기반 권한 흐름 제거 및 중앙 제어로 통합.
  - 권한 거부/오류 표시를 통일된 팝업(brakePopUp)으로 전환.
  - 앱 및 확장 대상에 개인정보 선언(PrivacyInfo.xcprivacy) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->